### PR TITLE
Fix github workflows

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v5
       with:
-        go-version: '^1.14'
+        go-version: '^1.21'
     - run: make generate
     - uses: EndBug/add-and-commit@v4
       with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v5
       with:
-        go-version: '^1.17'
+        go-version: '^1.21'
     - run: make generate

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ all: generate
 
 .PHONY: generate
 generate: $(JB_BIN) $(GOJSONTOYAML_BIN) $(JSONNET_BIN)
-	./hack/generate.sh
+	cd hack && ./generate.sh
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)
 
 $(TOOLING): $(BIN_DIR)
 	@echo Installing tools from hack/tools.go
-	@cd hack && go list -mod=mod -tags tools -f '{{ range .Imports }}{{ printf "%s\n" .}}{{end}}' ./ | xargs -tI % go build -mod=mod -o $(BIN_DIR) %
+	@cd hack && go list -mod=mod -e -tags tools -f '{{ range .Imports }}{{ printf "%s\n" .}}{{end}}' ./ | xargs -tI % go build -mod=mod -o $(BIN_DIR) %


### PR DESCRIPTION
they seemed to be installing 1.22.0, not the 1.14 specified, i suspect since its old enough to work on the latest runners

update to 1.21 (which i happened to have locally for testing) and fix go list to include -e which allows the imports to install to work